### PR TITLE
Add Circuit Diagram Maker to Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This is just a beginning.
 - [Circuito.io](https://www.circuito.io/app)
 - [Circuits.io](https://circuits.io/)
 - [Maker.io](https://www.digikey.com/en/maker)
+- [Circuit Diagram Maker](https://circuitdiagrammaker.app) - Browser-based editor for circuit and wiring diagrams with auto-routing wires and PDF/SVG/PNG export.
 
 ### Projects Resources
 


### PR DESCRIPTION
Adds **Circuit Diagram Maker** (https://circuitdiagrammaker.app) to the Platforms section.

It's a browser-based editor for circuit and wiring diagrams — drag symbols onto a canvas, wires auto-route, export PDF/SVG/PNG. Free tier with paid Pro. Sits alongside Circuits.io and Circuito.io as a browser-based option.

Disclosure: I'm involved with the project.